### PR TITLE
chore: set version in pyproject.toml as dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 
 requires-python = ">=3.8"
+dynamic = ["version"] # Calculated from the rust module version
 
 [project.urls]
 homepage = "https://unblob.org"


### PR DESCRIPTION
Version is a required property, setting it to dynamic means, that it will be generated during build-time.

This required for tools like `pdm` to be able to install this package in an editable manner directly from a remote.