### PR TITLE
nix: expose unblob-native as an overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,104 @@
+{ lib
+, stdenv
+, craneLib
+, nixFilter
+, maturin
+, rustPlatform
+, libiconv
+, python3
+}:
+
+let
+  src = craneLib.cleanCargoSource (craneLib.path ./.);
+
+  # Common arguments can be set here to avoid repeating them later
+  commonArgs = {
+    inherit src;
+
+    # python package  build will recompile PyO3 when built with maturin
+    # as there are different build features are used for the extension module
+    # and the standalone dylib which is used for tests and benchmarks
+    doNotLinkInheritedArtifacts = true;
+
+    buildInputs = [
+      python3
+    ] ++ lib.optionals stdenv.isDarwin [
+      # Additional darwin specific inputs can be set here
+      libiconv
+    ];
+  };
+
+  # Build *just* the cargo dependencies, so we can reuse
+  # all of that work (e.g. via cachix) when running in CI
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  # Build the actual crate itself, reusing the dependency
+  # artifacts from above.
+  libunblob-native = craneLib.buildPackage (commonArgs // {
+    inherit cargoArtifacts;
+  });
+  self = python3.pkgs.buildPythonPackage {
+
+    inherit (libunblob-native) pname version;
+    format = "pyproject";
+
+    src = nixFilter {
+      root = ./.;
+      include = [
+        "Cargo.toml"
+        "Cargo.lock"
+        "pyproject.toml"
+        "python"
+        "benches"
+        "src"
+        "README.md"
+        "LICENSE"
+      ];
+    };
+
+    buildInputs = commonArgs.buildInputs ++ [ maturin ];
+
+    strictDeps = true;
+    doCheck = false;
+    cargoDeps = rustPlatform.importCargoLock {
+      lockFile = ./Cargo.lock;
+    };
+
+    nativeBuildInputs =
+      (with rustPlatform; [
+        cargoSetupHook
+        maturinBuildHook
+      ]);
+
+
+    passthru = {
+      inherit cargoArtifacts craneLib commonArgs libunblob-native;
+      tests = {
+        pytest =
+          with python3.pkgs; buildPythonPackage
+            {
+              inherit (libunblob-native) pname version;
+              format = "other";
+
+              src = nixFilter
+                {
+                  root = ./.;
+                  include = [
+                    "pyproject.toml"
+                    "tests"
+                  ];
+                };
+
+              dontBuild = true;
+              dontInstall = true;
+
+              nativeCheckInputs = [
+                self
+                pytestCheckHook
+              ];
+            };
+      };
+    };
+  };
+in
+self

--- a/flake.lock
+++ b/flake.lock
@@ -54,24 +54,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nix-filter": {
       "locked": {
         "lastModified": 1701697642,
@@ -109,47 +91,10 @@
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1702088052,
-        "narHash": "sha256-FkwIBTAMsxyceQce0Mbm+/+cOjj2r5IHBK4R/ekPNaw=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "2cfb76b8e836a26efecd9f853bea78355a11c58a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
Nix recently started checking the consistency of python derivations: a python environment must refer only a single python interpreter and package set.

Unblob needs to be updated later to use this overlay.

During the rewrite some simplifications are made:
- use nix's default rust environment
- remove (unused) code coverage measurement for now