### PR TITLE
ci: replace macos-latest by macos-13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
             arch: x86_64-linux
           - os: ubuntu-latest
             arch: aarch64-linux
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64-darwin
     name: Build Nix - ${{ matrix.arch }}.${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -178,7 +178,7 @@ jobs:
           EOF
 
   wheel-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [checks, pytest, pyright]
     strategy:
       matrix:


### PR DESCRIPTION
`macos-14` is ARM based only, and `macos-latest` was recently transitioned from `macos-12` to `macos-14`, meaning we're no longer building for x86-64 and breaking the wheel build on OSX.

See https://github.com/actions/runner-images/issues/9741